### PR TITLE
Remove an unexpected left curly bracket from snippets/inno-setup.json

### DIFF
--- a/snippets/inno-setup.json
+++ b/snippets/inno-setup.json
@@ -755,7 +755,6 @@
     "prefix": "SignToolRetryDelay",
     "body": "SignToolRetryDelay=${1:500}$0"
   },
-  {
   "SignToolRunMinimized": {
     "prefix": "SignToolRunMinimized",
     "body": "SignToolRunMinimized=${1:yes|no}$0"


### PR DESCRIPTION
Hi. I got an error from vscode-linter when developing this extension:

```console
> innosetup@1.6.0 lint C:\vscode-innosetup
> vscode-linter

[09:06:30] Lint TypeScript: src\index.ts
[09:06:30] Lint JSON: package.json
[09:06:30] Lint XML: images\icon--build-dark.svg
[09:06:30] Lint TypeScript: src\iscc.ts        
[09:06:30] Lint JSON: snippets\inno-pascal.json
[09:06:30] Lint XML: images\icon--build-light.svg
[09:06:31] Lint TypeScript: src\task.ts
[09:06:31] Lint JSON: snippets\inno-setup.json

C:\vscode-innosetup\node_modules\map-stream\index.js:102
        throw err
        ^
[PluginError [JSONLintError]: Parse error on line 1756, column 1:
...ody": "zip$0"  }}
--------------------^
Unexpected end of input] {
  plugin: 'gulp-jsonlint',
  showProperties: true,
  showStack: false,
  __safety: { toString: [Function: bound ] }
}

```

This error message confused me, and after reviewing the file in VS Code, I found the extra left curly bracket.

This bracket was introduced in ebf0164abd47fc5bc3f7a7167191d17e9669729b by #27 .

---

In addition, when I opened this PR, a PR template from Atom is showed. Is there a wrong configuration in this repository?