### PR TITLE
Fix the tokenization of sections, especially the "Code" section

### DIFF
--- a/syntaxes/inno-setup.tmLanguage
+++ b/syntaxes/inno-setup.tmLanguage
@@ -29,14 +29,6 @@
             </dict>
             <key>end</key>
             <string>^(?i)(?=\[(Code|Components|CustomMessages|Dirs|Files|Icons|INI|InstallDelete|LangOptions|Languages|Messages|Registry|Run|Setup|Tasks|Types|UninstallDelete|UninstallRun)\]$)</string>
-            <key>endCaptures</key>
-            <dict>
-                <key>1</key>
-                <dict>
-                    <key>name</key>
-                    <string>entity.name.section.inno</string>
-                </dict>
-            </dict>
             <key>contentName</key>
             <string>source.pascal.embedded.inno</string>
             <key>patterns</key>

--- a/syntaxes/inno-setup.tmLanguage
+++ b/syntaxes/inno-setup.tmLanguage
@@ -18,7 +18,7 @@
         <!-- Inno Pascal section -->
         <dict>
             <key>begin</key>
-            <string>^(\[(?i)Code\])$</string>
+            <string>^\s*(\[(?i)Code\])\s*$</string>
             <key>beginCaptures</key>
             <dict>
                 <key>1</key>
@@ -28,7 +28,7 @@
                 </dict>
             </dict>
             <key>end</key>
-            <string>^(?i)(?=\[(Code|Components|CustomMessages|Dirs|Files|Icons|INI|InstallDelete|LangOptions|Languages|Messages|Registry|Run|Setup|Tasks|Types|UninstallDelete|UninstallRun)\]$)</string>
+            <string>^(?i)(?=\s*\[(Code|Components|CustomMessages|Dirs|Files|Icons|INI|InstallDelete|LangOptions|Languages|Messages|Registry|Run|Setup|Tasks|Types|UninstallDelete|UninstallRun)\]\s*$)</string>
             <key>contentName</key>
             <string>source.pascal.embedded.inno</string>
             <key>patterns</key>
@@ -71,9 +71,15 @@
 
         <dict>
             <key>match</key>
-            <string>^(?i)\[(Code|Components|CustomMessages|Dirs|Files|Icons|INI|InstallDelete|LangOptions|Languages|Messages|Registry|Run|Setup|Tasks|Types|UninstallDelete|UninstallRun)\]$</string>
-            <key>name</key>
-            <string>entity.name.section.inno</string>
+            <string>^\s*(?i)(\[(Code|Components|CustomMessages|Dirs|Files|Icons|INI|InstallDelete|LangOptions|Languages|Messages|Registry|Run|Setup|Tasks|Types|UninstallDelete|UninstallRun)\])\s*$</string>
+            <key>captures</key>
+            <dict>
+                <key>1</key>
+                <dict>
+                    <key>name</key>
+                    <string>entity.name.section.inno</string>
+                </dict>
+            </dict>
         </dict>
 
         <dict>

--- a/syntaxes/inno-setup.tmLanguage
+++ b/syntaxes/inno-setup.tmLanguage
@@ -28,7 +28,7 @@
                 </dict>
             </dict>
             <key>end</key>
-            <string>^(?i)(?=\[(Components|CustomMessages|Dirs|Files|Icons|INI|InstallDelete|LangOptions|Languages|Messages|Registry|Run|Setup|Tasks|Types|UninstallDelete|UninstallRun)\]$)</string>
+            <string>^(?i)(?=\[(Code|Components|CustomMessages|Dirs|Files|Icons|INI|InstallDelete|LangOptions|Languages|Messages|Registry|Run|Setup|Tasks|Types|UninstallDelete|UninstallRun)\]$)</string>
             <key>endCaptures</key>
             <dict>
                 <key>1</key>
@@ -79,7 +79,7 @@
 
         <dict>
             <key>match</key>
-            <string>^(?i)\[(Components|CustomMessages|Dirs|Files|Icons|INI|InstallDelete|LangOptions|Languages|Messages|Registry|Run|Setup|Tasks|Types|UninstallDelete|UninstallRun)\]$</string>
+            <string>^(?i)\[(Code|Components|CustomMessages|Dirs|Files|Icons|INI|InstallDelete|LangOptions|Languages|Messages|Registry|Run|Setup|Tasks|Types|UninstallDelete|UninstallRun)\]$</string>
             <key>name</key>
             <string>entity.name.section.inno</string>
         </dict>

--- a/syntaxes/inno-setup.tmLanguage
+++ b/syntaxes/inno-setup.tmLanguage
@@ -28,7 +28,7 @@
                 </dict>
             </dict>
             <key>end</key>
-            <string>^(?i)(?=\[(Components|CustomMessages|Dirs|Files|Icons|INI|InstallDelete|LangOptions|Languages|Messages|Registry|Run|Setup|Tasks|Types|UninstallDelete|UninstallRun)\])$</string>
+            <string>^(?i)(?=\[(Components|CustomMessages|Dirs|Files|Icons|INI|InstallDelete|LangOptions|Languages|Messages|Registry|Run|Setup|Tasks|Types|UninstallDelete|UninstallRun)\]$)</string>
             <key>endCaptures</key>
             <dict>
                 <key>1</key>

--- a/syntaxes/inno-setup.tmLanguage
+++ b/syntaxes/inno-setup.tmLanguage
@@ -37,7 +37,7 @@
                     <string>entity.name.section.inno</string>
                 </dict>
             </dict>
-            <key>name</key>
+            <key>contentName</key>
             <string>source.pascal.embedded.inno</string>
             <key>patterns</key>
             <array>


### PR DESCRIPTION
Hi.

I tested the following code on [Inno Setup 6.0.5](https://files.jrsoftware.org/is/6/innosetup-6.0.5.exe) and it works fine.

<details>
<summary>Inno Setup code</summary>

```
		[Setup]		
AppId=appID
	[Setup]	
AppName=appName
  [Setup]  
AppVersion=1.0
 [Setup] 
AppPublisher=publisher
 [Setup]
DefaultDirName={autopf}\appName
[Setup] 
PrivilegesRequired=lowest

		[Code]		
var number_0: Integer;
	[Code]	
var number_1: Integer;
  [Code]  
var number_2: Integer;
 [Code] 
var number_3: Integer;
[Code] 
var number_4: Integer;
 [Code]
var number_5: Integer;

[Code]
var string_0: String;
[Code]
var string_1: String;
[Setup]
AppCopyright=copyleft
[Code]
var boolean_0: Boolean;

```

</details>

Comparison:

| Before | After
| - | -
| ![20210609_before](https://user-images.githubusercontent.com/29089388/121326527-3ab81100-c945-11eb-96a8-c4699b1b9261.png) | ![20210609_after](https://user-images.githubusercontent.com/29089388/121326535-3c81d480-c945-11eb-94ff-70c17aacee3b.png)

Theme: Solarized Dark shipped with VS Code.

Please see the commit message for details.